### PR TITLE
Fix convert flatten

### DIFF
--- a/test/layers/reshapes/test_flatten.py
+++ b/test/layers/reshapes/test_flatten.py
@@ -15,9 +15,18 @@ class LayerTest(nn.Module):
 
 
 @pytest.mark.parametrize('change_ordering', [True, False])
-def test_flatten(change_ordering):
+def test_flatten_image(change_ordering):
     model = LayerTest()
     model.eval()
 
-    input_np = np.random.uniform(0, 1, (1, 1, 512))
+    input_np = np.random.uniform(0, 1, (1, 3, 224, 224))
+    error = convert_and_test(model, input_np, verbose=False, change_ordering=change_ordering)
+
+
+@pytest.mark.parametrize('change_ordering', [True, False])
+def test_flatten_vec(change_ordering):
+    model = LayerTest()
+    model.eval()
+
+    input_np = np.random.uniform(0, 1, (1, 512, 1, 1))
     error = convert_and_test(model, input_np, verbose=False, change_ordering=change_ordering)


### PR DESCRIPTION
99f9fad fix does not give correct result. We need to convert the input data to channels-first format - this does work only if all non-channels dimensions are equal to 1 -.
This fixes it by using a `Permute` layer to convert input data format to channels-first if needed.