### PR TITLE
Fix convert reshape

### DIFF
--- a/onnx2keras/reshape_layers.py
+++ b/onnx2keras/reshape_layers.py
@@ -179,8 +179,6 @@ def convert_reshape(node, params, layers, lambda_func, node_name, keras_name):
             else:
                 input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const" % keras_name)
                 logger.debug('The first argument is Keras/tf layer. Apply keras.Reshape.')
-                logger.debug('Target shape :')
-                logger.debug(np.int32(input_1[1:]))
 
                 if len(np.int32(input_1[1:])) == 1 and np.int32(input_1[1:])[0] == -1:
                     logger.debug('The first argument is Keras/tf layer. Apply keras.Flatten.')

--- a/onnx2keras/reshape_layers.py
+++ b/onnx2keras/reshape_layers.py
@@ -151,6 +151,7 @@ def convert_reshape(node, params, layers, lambda_func, node_name, keras_name):
             logger.debug('The first argument is numpy array. Apply np.reshape.')
             layers[node_name] = np.reshape(input_0, np.int32(input_1))
         else:
+            logger.debug('The first argument is Keras/tf layer. Apply keras.Reshape.')
             input_0 = ensure_tf_type(input_0, layers[list(layers)[0]], name="%s_const" % keras_name)
             if params['change_ordering']:
 
@@ -163,14 +164,8 @@ def convert_reshape(node, params, layers, lambda_func, node_name, keras_name):
                     permute = keras.layers.Permute(permutation, name="%s_to_channels_first" % keras_name if keras_name is not None else None)
                     input_0 = permute(input_0)
 
-                reshape = keras.layers.Reshape(input_1[1:], name=keras_name)
-                layers[node_name] = reshape(input_0)
-
-            else:
-                logger.debug('The first argument is Keras/tf layer. Apply keras.Reshape.')
-
-                reshape = keras.layers.Reshape(input_1[1:], name=keras_name)
-                layers[node_name] = reshape(input_0)
+            reshape = keras.layers.Reshape(input_1[1:], name=keras_name)
+            layers[node_name] = reshape(input_0)
     else:
         raise AttributeError('Can\'t reshape dynamic size.')
 

--- a/onnx2keras/reshape_layers.py
+++ b/onnx2keras/reshape_layers.py
@@ -179,13 +179,8 @@ def convert_reshape(node, params, layers, lambda_func, node_name, keras_name):
             else:
                 logger.debug('The first argument is Keras/tf layer. Apply keras.Reshape.')
 
-                if len(np.int32(input_1[1:])) == 1 and np.int32(input_1[1:])[0] == -1:
-                    logger.debug('The first argument is Keras/tf layer. Apply keras.Flatten.')
-                    flatten = keras.layers.Flatten(name=keras_name)
-                    layers[node_name] = flatten(input_0)
-                else:
-                    reshape = keras.layers.Reshape(np.int32(input_1[1:]), name=keras_name)
-                    layers[node_name] = reshape(input_0)
+                reshape = keras.layers.Reshape(input_1[1:], name=keras_name)
+                layers[node_name] = reshape(input_0)
     else:
         raise AttributeError('Can\'t reshape dynamic size.')
 

--- a/onnx2keras/reshape_layers.py
+++ b/onnx2keras/reshape_layers.py
@@ -151,8 +151,8 @@ def convert_reshape(node, params, layers, lambda_func, node_name, keras_name):
             logger.debug('The first argument is numpy array. Apply np.reshape.')
             layers[node_name] = np.reshape(input_0, np.int32(input_1))
         else:
+            input_0 = ensure_tf_type(input_0, layers[list(layers)[0]], name="%s_const" % keras_name)
             if params['change_ordering']:
-                input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const" % keras_name)
 
                 # Fix critical issue with NHWC
                 if input_1[0] is None and input_1[1] == -1:
@@ -177,7 +177,6 @@ def convert_reshape(node, params, layers, lambda_func, node_name, keras_name):
                 layers[node_name] = reshape(layers[node_name])
 
             else:
-                input_0 = ensure_tf_type(layers[node.input[0]], layers[list(layers)[0]], name="%s_const" % keras_name)
                 logger.debug('The first argument is Keras/tf layer. Apply keras.Reshape.')
 
                 if len(np.int32(input_1[1:])) == 1 and np.int32(input_1[1:])[0] == -1:

--- a/test/layers/reshapes/test_reshape.py
+++ b/test/layers/reshapes/test_reshape.py
@@ -32,7 +32,8 @@ class UnflattenLayerTest(nn.Module):
         return x
 
 
-@pytest.mark.parametrize('change_ordering', [True, False])
+xfail_reason = "impossible for reshaped outputs to match between if the prediction is not done in with the same orderning"
+@pytest.mark.parametrize('change_ordering', [pytest.param(True, marks=pytest.mark.xfail(reason=xfail_reason)), False])
 def test_reshape_unflatten(change_ordering):
     model = UnflattenLayerTest()
     model.eval()

--- a/test/layers/reshapes/test_reshape.py
+++ b/test/layers/reshapes/test_reshape.py
@@ -1,0 +1,40 @@
+import numpy as np
+import torch.nn as nn
+import pytest
+
+from test.utils import convert_and_test
+
+
+class FlattenLayerTest(nn.Module):
+    def __init__(self):
+        super(FlattenLayerTest, self).__init__()
+
+    def forward(self, x):
+        x = x.reshape(x.size(0), -1)
+        return x
+
+
+@pytest.mark.parametrize('change_ordering', [True, False])
+def test_reshape_flatten(change_ordering):
+    model = FlattenLayerTest()
+    model.eval()
+
+    input_np = np.random.uniform(0, 1, (1, 3, 224, 224))
+    error = convert_and_test(model, input_np, verbose=False, change_ordering=change_ordering)
+
+
+class UnflattenLayerTest(nn.Module):
+    def __init__(self):
+        super(UnflattenLayerTest, self).__init__()
+
+    def forward(self, x):
+        x = x.reshape(x.size(0), 3, 224, 224)
+        return x
+
+
+@pytest.mark.parametrize('change_ordering', [True, False])
+def test_reshape_unflatten(change_ordering):
+    model = UnflattenLayerTest()
+    model.eval()
+    input_np = np.random.uniform(0, 1, (1, 150528,))
+    error = convert_and_test(model, input_np, verbose=False, change_ordering=change_ordering)


### PR DESCRIPTION
Fix reshape giving incorrect results in some cases, and remove the use of `Lambda` layers.
Also add missing unit test for reshape.