### PR TITLE
Remove `Permute` layer if needless in reshape/flatten convert

### DIFF
--- a/test/layers/reshapes/test_flatten.py
+++ b/test/layers/reshapes/test_flatten.py
@@ -15,7 +15,7 @@ class LayerTest(nn.Module):
 
 
 @pytest.mark.parametrize('change_ordering', [True, False])
-def test_flatten_image(change_ordering):
+def test_flatten(change_ordering):
     model = LayerTest()
     model.eval()
 

--- a/test/layers/reshapes/test_reshape.py
+++ b/test/layers/reshapes/test_reshape.py
@@ -23,6 +23,15 @@ def test_reshape_flatten(change_ordering):
     error = convert_and_test(model, input_np, verbose=False, change_ordering=change_ordering)
 
 
+@pytest.mark.parametrize('change_ordering', [True, False])
+def test_reshape_flatten_vec(change_ordering):
+    model = FlattenLayerTest()
+    model.eval()
+
+    input_np = np.random.uniform(0, 1, (1, 512, 1, 1))
+    error = convert_and_test(model, input_np, verbose=False, change_ordering=change_ordering)
+
+
 class UnflattenLayerTest(nn.Module):
     def __init__(self):
         super(UnflattenLayerTest, self).__init__()

--- a/test/layers/reshapes/test_reshape.py
+++ b/test/layers/reshapes/test_reshape.py
@@ -41,7 +41,7 @@ class UnflattenLayerTest(nn.Module):
         return x
 
 
-xfail_reason = "impossible for reshaped outputs to match between if the prediction is not done in with the same orderning"
+xfail_reason = "impossible for reshaped outputs to match between if the prediction is not done in with the same ordering"
 @pytest.mark.parametrize('change_ordering', [pytest.param(True, marks=pytest.mark.xfail(reason=xfail_reason)), False])
 def test_reshape_unflatten(change_ordering):
     model = UnflattenLayerTest()


### PR DESCRIPTION
In reshape and flatten converts, if `change_ordering=True`, it is necessary to transpose the input channels-first format to get the correct result only if all non-channels dimensions of the input are not equal to 1.

This removes the `Permute` layer if this latter condition is not satisfied.