### PR TITLE
Add "keras" name policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ TensorFlow 2.0
 
 `input_shapes`: override input shapes (experimental)
 
-`name_policy`: ['renumerate', 'short', 'default'] override layer names (experimental)
+`name_policy`: override layer names. None, "short" or "renumerate", or "keras" (experimental)
+    - None uses the ONNX graph node output name
+    - "short" takes the first 8 characters of the ONNX graph node
+    - "renumerate" is the prefix 'LAYER_' followed by the node number in conversion order
+    - "keras" uses Keras layer default names
 
 `verbose`: detailed output
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ TensorFlow 2.0
 
 `input_shapes`: override input shapes (experimental)
 
-`name_policy`: override layer names. None, "short" or "renumerate", or "keras" (experimental)
-    - None uses the ONNX graph node output name
-    - "short" takes the first 8 characters of the ONNX graph node
-    - "renumerate" is the prefix 'LAYER_' followed by the node number in conversion order
-    - "keras" uses Keras layer default names
+`name_policy`: override layer names. None, "short" or "renumerate", or "keras" (experimental):
+    - None uses the ONNX graph node output name.
+    - "short" takes the first 8 characters of the ONNX graph node.
+    - "renumerate" is the prefix 'LAYER_' followed by the node number in conversion order.
+    - "keras" uses Keras layer default names (with the advantage to give understandable and easy to process names).
 
 `verbose`: detailed output
 

--- a/onnx2keras/activation_layers.py
+++ b/onnx2keras/activation_layers.py
@@ -148,7 +148,7 @@ def convert_softmax(node, params, layers, lambda_func, node_name, keras_name):
     lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
     layers[node_name] = lambda_layer(input_0)
     layers[node_name].set_shape(layers[node_name].shape)
-    lambda_func[keras_name] = target_layer
+    lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_prelu(node, params, layers, lambda_func, node_name, keras_name):

--- a/onnx2keras/converter.py
+++ b/onnx2keras/converter.py
@@ -43,11 +43,11 @@ def onnx_to_keras(onnx_model, input_names,
     :param onnx_model: loaded ONNX model
     :param input_names: list with input names
     :param input_shapes: override input shapes (experimental)
-    :param name_policy: override layer names. None, "short" or "renumerate", or "keras" (experimental).
-        - None uses the ONNX graph node output name
-        - "short" takes the first 8 characters of the ONNX graph node
-        - "renumerate" is the prefix 'LAYER_' followed by the node number in conversion order
-        - "keras" uses Keras layer default names
+    :param name_policy: override layer names. None, "short" or "renumerate", or "keras" (experimental):
+        - None uses the ONNX graph node output name.
+        - "short" takes the first 8 characters of the ONNX graph node.
+        - "renumerate" is the prefix 'LAYER_' followed by the node number in conversion order.
+        - "keras" uses Keras layer default names (with the advantage to give understandable and easy to process names).
     :param verbose: verbose output
     :param change_ordering: change ordering to HWC (experimental)
     :return: Keras model

--- a/onnx2keras/converter.py
+++ b/onnx2keras/converter.py
@@ -47,7 +47,7 @@ def onnx_to_keras(onnx_model, input_names,
         - None uses the ONNX graph node output name
         - "short" takes the first 8 characters of the ONNX graph node
         - "renumerate" is the prefix 'LAYER_' followed by the node number in conversion order
-        - "keras" uses Keras layer default names (not implemented)
+        - "keras" uses Keras layer default names
     :param verbose: verbose output
     :param change_ordering: change ordering to HWC (experimental)
     :return: Keras model

--- a/onnx2keras/converter.py
+++ b/onnx2keras/converter.py
@@ -141,7 +141,7 @@ def onnx_to_keras(onnx_model, input_names,
                 postfix = node_index if len(node.output) == 1 else "%s_%s" % (node_index, output_index)
                 keras_names.append('LAYER_%s' % postfix)
             elif name_policy == "keras":
-                raise NotImplementedError("name_policy value 'keras' is not implemented")
+                keras_names.append(None)
             else:
                 keras_names.append(output)
 

--- a/onnx2keras/converter.py
+++ b/onnx2keras/converter.py
@@ -43,7 +43,11 @@ def onnx_to_keras(onnx_model, input_names,
     :param onnx_model: loaded ONNX model
     :param input_names: list with input names
     :param input_shapes: override input shapes (experimental)
-    :param name_policy: override layer names. None, "short" or "renumerate" (experimental)
+    :param name_policy: override layer names. None, "short" or "renumerate", or "keras" (experimental).
+        - None uses the ONNX graph node output name
+        - "short" takes the first 8 characters of the ONNX graph node
+        - "renumerate" is the prefix 'LAYER_' followed by the node number in conversion order
+        - "keras" uses Keras layer default names (not implemented)
     :param verbose: verbose output
     :param change_ordering: change ordering to HWC (experimental)
     :return: Keras model
@@ -136,6 +140,8 @@ def onnx_to_keras(onnx_model, input_names,
             elif name_policy == 'renumerate':
                 postfix = node_index if len(node.output) == 1 else "%s_%s" % (node_index, output_index)
                 keras_names.append('LAYER_%s' % postfix)
+            elif name_policy == "keras":
+                raise NotImplementedError("name_policy value 'keras' is not implemented")
             else:
                 keras_names.append(output)
 

--- a/onnx2keras/elementwise_layers.py
+++ b/onnx2keras/elementwise_layers.py
@@ -36,7 +36,7 @@ def convert_elementwise_div(node, params, layers, lambda_func, node_name, keras_
 
         lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
         layers[node_name] = lambda_layer([input_0, input_1])
-        lambda_func[keras_name] = target_layer
+        lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_elementwise_add(node, params, layers, lambda_func, node_name, keras_name):
@@ -79,7 +79,7 @@ def convert_elementwise_add(node, params, layers, lambda_func, node_name, keras_
 
         lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
         layers[node_name] = lambda_layer([input_0, input_1])
-        lambda_func[keras_name] = target_layer
+        lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_elementwise_mul(node, params, layers, lambda_func, node_name, keras_name):
@@ -120,7 +120,7 @@ def convert_elementwise_mul(node, params, layers, lambda_func, node_name, keras_
 
         lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
         layers[node_name] = lambda_layer([input_0, input_1])
-        lambda_func[keras_name] = target_layer
+        lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_elementwise_sub(node, params, layers, lambda_func, node_name, keras_name):
@@ -161,7 +161,7 @@ def convert_elementwise_sub(node, params, layers, lambda_func, node_name, keras_
 
         lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
         layers[node_name] = lambda_layer([input_0, input_1])
-        lambda_func[keras_name] = target_layer
+        lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_min(node, params, layers, lambda_func, node_name, keras_name):

--- a/onnx2keras/linear_layers.py
+++ b/onnx2keras/linear_layers.py
@@ -46,7 +46,7 @@ def convert_gemm(node, params, layers, lambda_func, node_name, keras_name):
         try:
             layers[node_name] = dense(layers[node.input[0]])
         except ValueError:
-            reshape = keras.layers.Reshape([input_channels], name=keras_name + '_reshape')
+            reshape = keras.layers.Reshape([input_channels], name=keras_name + '_reshape' if keras_name is not None else None)
             reshaped_x = reshape(layers[node.input[0]])
             layers[node_name] = dense(reshaped_x)
     

--- a/onnx2keras/normalization_layers.py
+++ b/onnx2keras/normalization_layers.py
@@ -152,4 +152,4 @@ def convert_lrn(node, params, layers, lambda_func, node_name, keras_name):
 
     lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
     layers[node_name] = lambda_layer(input_0)
-    lambda_func[keras_name] = target_layer
+    lambda_func[lambda_layer.name] = target_layer

--- a/onnx2keras/operation_layers.py
+++ b/onnx2keras/operation_layers.py
@@ -35,10 +35,12 @@ def convert_clip(node, params, layers, lambda_func, node_name, keras_name):
         def target_layer(x, vmin=params['min'], vmax=params['max']):
             import tensorflow as tf
             return tf.clip_by_value(x, vmin, vmax)
+
         lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
         lambda_func[lambda_layer.name] = target_layer
+        layer = lambda_layer
 
-    layers[node_name] = lambda_layer(input_0)
+    layers[node_name] = layer(input_0)
 
 
 def convert_log(node, params, layers, lambda_func, node_name, keras_name):

--- a/onnx2keras/operation_layers.py
+++ b/onnx2keras/operation_layers.py
@@ -35,10 +35,10 @@ def convert_clip(node, params, layers, lambda_func, node_name, keras_name):
         def target_layer(x, vmin=params['min'], vmax=params['max']):
             import tensorflow as tf
             return tf.clip_by_value(x, vmin, vmax)
-        layer = keras.layers.Lambda(target_layer, name=keras_name)
-        lambda_func[keras_name] = target_layer
+        lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
+        lambda_func[lambda_layer.name] = target_layer
 
-    layers[node_name] = layer(input_0)
+    layers[node_name] = lambda_layer(input_0)
 
 
 def convert_log(node, params, layers, lambda_func, node_name, keras_name):
@@ -63,7 +63,7 @@ def convert_log(node, params, layers, lambda_func, node_name, keras_name):
 
     lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
     layers[node_name] = lambda_layer(input_0)
-    lambda_func[keras_name] = target_layer
+    lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_exp(node, params, layers, lambda_func, node_name, keras_name):
@@ -87,7 +87,7 @@ def convert_exp(node, params, layers, lambda_func, node_name, keras_name):
 
     lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
     layers[node_name] = lambda_layer(input_0)
-    lambda_func[keras_name] = target_layer
+    lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_reduce_sum(node, params, layers, lambda_func, node_name, keras_name):
@@ -115,7 +115,7 @@ def convert_reduce_sum(node, params, layers, lambda_func, node_name, keras_name)
     lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
     layers[node_name] = lambda_layer(input_0)
     layers[node_name].set_shape(layers[node_name].shape)
-    lambda_func[keras_name] = target_layer
+    lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_reduce_mean(node, params, layers, lambda_func, node_name, keras_name):
@@ -141,7 +141,7 @@ def convert_reduce_mean(node, params, layers, lambda_func, node_name, keras_name
     lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
     layers[node_name] = lambda_layer(input_0)
     layers[node_name].set_shape(layers[node_name].shape)
-    lambda_func[keras_name] = target_layer
+    lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_reduce_max(node, params, layers, lambda_func, node_name, keras_name):
@@ -167,7 +167,7 @@ def convert_reduce_max(node, params, layers, lambda_func, node_name, keras_name)
     lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
     layers[node_name] = lambda_layer(input_0)
     layers[node_name].set_shape(layers[node_name].shape)
-    lambda_func[keras_name] = target_layer
+    lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_pow(node, params, layers, lambda_func, node_name, keras_name):
@@ -193,7 +193,7 @@ def convert_pow(node, params, layers, lambda_func, node_name, keras_name):
 
     lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
     layers[node_name] = lambda_layer(input_0)
-    lambda_func[keras_name] = target_layer
+    lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_sqrt(node, params, layers, lambda_func, node_name, keras_name):
@@ -218,7 +218,7 @@ def convert_sqrt(node, params, layers, lambda_func, node_name, keras_name):
 
     lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
     layers[node_name] = lambda_layer(input_0)
-    lambda_func[keras_name] = target_layer
+    lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_split(node, params, layers, lambda_func, node_name, keras_names):
@@ -254,7 +254,7 @@ def convert_split(node, params, layers, lambda_func, node_name, keras_names):
 
         lambda_layer = keras.layers.Lambda(target_layer, name=keras_names[i])
         layers[node_name] = lambda_layer(input_0)
-        lambda_func[keras_names[i]] = target_layer
+        lambda_func[lambda_layer.name] = target_layer
         cur += split
 
 
@@ -310,7 +310,7 @@ def convert_cast(node, params, layers, lambda_func, node_name, keras_name):
 
         lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
         layers[node_name] = lambda_layer(input_0)
-        lambda_func[keras_name] = target_layer
+        lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_floor(node, params, layers, lambda_func, node_name, keras_name):
@@ -336,7 +336,7 @@ def convert_floor(node, params, layers, lambda_func, node_name, keras_name):
 
     lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
     layers[node_name] = lambda_layer(input_0)
-    lambda_func[keras_name] = target_layer
+    lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_identity(node, params, layers, lambda_func, node_name, keras_name):
@@ -379,7 +379,7 @@ def convert_argmax(node, params, layers, lambda_func, node_name, keras_name):
 
     lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
     layers[node_name] = lambda_layer(input_0)
-    lambda_func[keras_name] = target_layer
+    lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_reduce_l2(node, params, layers, lambda_func, node_name, keras_name):
@@ -409,4 +409,4 @@ def convert_reduce_l2(node, params, layers, lambda_func, node_name, keras_name):
 
     lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
     layers[node_name] = lambda_layer(input_0)
-    lambda_func[keras_name] = target_layer
+    lambda_func[lambda_layer.name] = target_layer

--- a/onnx2keras/padding_layers.py
+++ b/onnx2keras/padding_layers.py
@@ -57,7 +57,7 @@ def convert_padding(node, params, layers, lambda_func, node_name, keras_name):
 
         lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
         layers[node_name] = lambda_layer(input_0)
-        lambda_func[keras_name] = target_layer
+        lambda_func[lambda_layer.name] = target_layer
     elif params['mode'] == 'edge':
 
         def target_layer(x, pads=pads):
@@ -71,7 +71,7 @@ def convert_padding(node, params, layers, lambda_func, node_name, keras_name):
 
         lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
         layers[node_name] = lambda_layer(input_0)
-        lambda_func[keras_name] = target_layer
+        lambda_func[lambda_layer.name] = target_layer
 
     else:
         raise AttributeError('Unknown padding')

--- a/onnx2keras/pooling_layers.py
+++ b/onnx2keras/pooling_layers.py
@@ -31,7 +31,7 @@ def convert_maxpool(node, params, layers, lambda_func, node_name, keras_name):
         logger.debug('Use `same` padding parameters.')
     else:
         logger.warning('Unable to use `same` padding. Add ZeroPadding2D layer to fix shapes.')
-        padding_name = keras_name + '_pad'
+        padding_name = keras_name + '_pad' if keras_name is not None else None
         if len(kernel_shape) == 2:
             padding = None
 
@@ -45,13 +45,13 @@ def convert_maxpool(node, params, layers, lambda_func, node_name, keras_name):
                     padding=padding,
                     name=padding_name
                 )
-                layers[padding_name] = input_0 = padding_layer(input_0)
+                layers[padding_layer.name] = input_0 = padding_layer(input_0)
         else:  # 3D padding
             padding_layer = keras.layers.ZeroPadding3D(
                 padding=pads[:len(stride_shape)],
                 name=padding_name
             )
-            layers[padding_name] = input_0 = padding_layer(input_0)
+            layers[padding_layer.name] = input_0 = padding_layer(input_0)
     if len(kernel_shape) == 2:
         pooling = keras.layers.MaxPooling2D(
             pool_size=kernel_shape,
@@ -100,7 +100,7 @@ def convert_avgpool(node, params, layers, lambda_func, node_name, keras_name):
         logger.debug('Use `same` padding parameters.')
     else:
         logger.warning('Unable to use `same` padding. Add ZeroPadding2D layer to fix shapes.')
-        padding_name = keras_name + '_pad'
+        padding_name = keras_name + '_pad' if keras_name is not None else None
         if len(kernel_shape) == 2:
             padding_layer = keras.layers.ZeroPadding2D(
                 padding=pads[:len(stride_shape)],
@@ -111,7 +111,7 @@ def convert_avgpool(node, params, layers, lambda_func, node_name, keras_name):
                 padding=pads[:len(stride_shape)],
                 name=padding_name
             )
-        layers[padding_name] = input_0 = padding_layer(input_0)
+        layers[padding_layer.name] = input_0 = padding_layer(input_0)
     if len(kernel_shape) == 2:
         pooling = keras.layers.AveragePooling2D(
             pool_size=kernel_shape,
@@ -156,7 +156,7 @@ def convert_global_avg_pool(node, params, layers, lambda_func, node_name, keras_
 
         global_pool = keras.layers.GlobalAveragePooling2D(data_format='channels_first', name=keras_name)
         output_0 = global_pool(input_0)
-        reshape = keras.layers.Reshape(output_0.shape[1:] + (1, 1), name=keras_name + '_expand')
+        reshape = keras.layers.Reshape(output_0.shape[1:] + (1, 1), name=keras_name + '_expand' if keras_name is not None else None)
         output_0 = reshape(output_0)
 
     layers[node_name] = output_0

--- a/onnx2keras/reshape_layers.py
+++ b/onnx2keras/reshape_layers.py
@@ -208,7 +208,7 @@ def convert_unsqueeze(node, params, layers, lambda_func, node_name, keras_name):
 
         lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
         layers[node_name] = lambda_layer(layers[node.input[0]])
-        lambda_func[keras_name] = target_layer
+        lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_flatten(node, params, layers, lambda_func, node_name, keras_name):
@@ -316,7 +316,7 @@ def convert_slice(node, params, layers, lambda_func, node_name, keras_name):
 
             lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
             layers[node_name] = lambda_layer(input_0)
-            lambda_func[keras_name] = target_layer
+            lambda_func[lambda_layer.name] = target_layer
         else:
             def target_layer(x, axis=axes, starts=starts, ends=ends):
                 import tensorflow as tf
@@ -331,7 +331,7 @@ def convert_slice(node, params, layers, lambda_func, node_name, keras_name):
 
             lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
             layers[node_name] = lambda_layer(input_0)
-            lambda_func[keras_name] = target_layer
+            lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_squeeze(node, params, layers, lambda_func, node_name, keras_name):
@@ -356,7 +356,7 @@ def convert_squeeze(node, params, layers, lambda_func, node_name, keras_name):
 
     lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
     layers[node_name] = lambda_layer(input_0)
-    lambda_func[keras_name] = target_layer
+    lambda_func[lambda_layer.name] = target_layer
 
 
 def convert_expand(node, params, layers, lambda_func, node_name, keras_name):
@@ -395,4 +395,4 @@ def convert_expand(node, params, layers, lambda_func, node_name, keras_name):
 
     lambda_layer = keras.layers.Lambda(target_layer, name=keras_name)
     layers[node_name] = lambda_layer(input_0)
-    lambda_func[keras_name] = target_layer
+    lambda_func[lambda_layer.name] = target_layer


### PR DESCRIPTION
Add "keras" value for `name_policy` argument to `onnx_to_keras`. This uses the default Keras layers names. The advantage of default Keras layer names is that they are understandable and easy to process, as they include the layer class names and unique identifiers across layers of the same type. None of the other available value for `name_policy` give meaningful names.
!! Warning: experimental.