### PR TITLE
Add argument to raise an error if the obtained Keras model is composed of at least one `Lambda` layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ TensorFlow 2.0
 
 ## API
 
-*function* `onnx_to_keras(onnx_model: onnx.ModelProto, input_names: Sequence[str], input_shapes: Sequence[Tuple[Optional[int]]] = None, name_policy: str = None, verbose: bool = True, change_ordering: bool = False) -> tf.keras.Model`
+*function* `onnx_to_keras(onnx_model: onnx.ModelProto, input_names: Sequence[str], input_shapes: Sequence[Tuple[Optional[int]]] = None, name_policy: str = None, verbose: bool = True, change_ordering: bool = False, raise_error_on_lambda_layers: bool = False) -> tf.keras.Model`
 
 >   Convert an ONNX graph to a Keras model.
 >   * `onnx_model`: loaded ONNX model
@@ -30,6 +30,10 @@ TensorFlow 2.0
 >   * `verbose`: verbose output
 >   * `change_ordering`: change tensor dimensions ordering, from channels-first (batch, channels, ...) to channels-last (batch, ..., channels).
 >           True should be considered experimental; it applies manual tweaks for certain layers to (hopefully) get the same output at the end.
+>   * `raise_error_on_lambda_layers`: raise an error if the obtained Keras model is composed of at least one `tf.keras.layers.Lambda` layer.
+        Use this as a sanity check if you intend to load the converted Keras model in a different environment; indeed, deserializing a model
+        with `Lambda` layers in a different environment where it was saved will results in an error when calling it. This is a limitation of `Lambda`
+        layers, (according to [Keras docs on Lambda layer](https://keras.io/api/layers/core_layers/lambda/)).
 
 
 ## Getting started

--- a/onnx2keras/converter.py
+++ b/onnx2keras/converter.py
@@ -63,7 +63,7 @@ def onnx_to_keras(onnx_model: onnx.ModelProto,
     :param raise_error_on_lambda_layers: raise an error if the obtained Keras model is composed of at least one `tf.keras.layers.Lambda` layer.
         Use this as a sanity check if you intend to load the converted Keras model in a different environment; indeed, deserializing a model
         with `Lambda` layers in a different environment where it was saved will results in an error when calling it. This is a limitation of `Lambda`
-        layers, ((according to Keras docs on Lambda layer)[https://keras.io/api/layers/core_layers/lambda/]).
+        layers, (according to [Keras docs on Lambda layer](https://keras.io/api/layers/core_layers/lambda/).
     """
     # Use channels first format by default.
     keras_fmt = keras.backend.image_data_format()

--- a/onnx2keras/exceptions.py
+++ b/onnx2keras/exceptions.py
@@ -1,0 +1,14 @@
+from tensorflow import keras
+
+
+class LambdaLayerError(Exception):
+    """Error with the presence of a keras `Lambda` layer.
+
+    :param lambda_layer: the Keras lambda layer object
+    """
+    def __init__(self, lambda_layer: keras.layers.Lambda):
+
+        self.lambda_layer: keras.layers.Lambda = lambda_layer
+        error_msg = f"the lambda layer is: {str(lambda_layer)}"
+
+        super().__init__(error_msg)

--- a/onnx2keras/exceptions.py
+++ b/onnx2keras/exceptions.py
@@ -9,6 +9,18 @@ class LambdaLayerError(Exception):
     def __init__(self, lambda_layer: keras.layers.Lambda):
 
         self.lambda_layer: keras.layers.Lambda = lambda_layer
-        error_msg = f"the lambda layer is: {str(lambda_layer)}"
+        error_msg = f"{self._lambda_layer_as_str(lambda_layer)}"
 
         super().__init__(error_msg)
+
+    @staticmethod
+    def _lambda_layer_as_str(layer: keras.layers.Lambda) -> str:
+        return (
+            f"{layer.__class__.__name__}("
+            f"name={layer.name}, "
+            f"function={layer.function}, "
+            f"output_shape={layer.output_shape}, "
+            f"mask={layer.mask}, "
+            f"arguments={layer.arguments}"
+            ")"
+        )

--- a/test/layers/operations/test_clip.py
+++ b/test/layers/operations/test_clip.py
@@ -2,7 +2,8 @@ import torch.nn as nn
 import numpy as np
 import pytest
 
-from test.utils import convert_and_test
+from test.utils import convert_and_test, convert
+from onnx2keras.exceptions import LambdaLayerError
 
 
 class FClipTest(nn.Module):
@@ -26,3 +27,13 @@ def test_clip(change_ordering):
     input_np = np.random.uniform(0, 1, (1, 3, 224, 224))
 
     error = convert_and_test(model, input_np, verbose=False, change_ordering=change_ordering)
+
+
+@pytest.mark.parametrize('change_ordering', [True, False])
+def test_clip_raise_error_on_lambda_layers(change_ordering):
+    model = FClipTest()
+    model.eval()
+
+    input_np = np.random.uniform(0, 1, (1, 3, 224, 224))
+    with pytest.raises(LambdaLayerError) as excinfo:
+        k_model = convert(model, input_np, verbose=False, change_ordering=change_ordering, raise_error_on_lambda_layers=True)

--- a/test/utils.py
+++ b/test/utils.py
@@ -6,7 +6,13 @@ import onnx
 from onnx2keras import onnx_to_keras, check_torch_keras_error
 
 
-def torch2keras(model: torch.nn.Module, input_variable, keras_input_shapes=None, name_policy=None, verbose=True, change_ordering=False):
+def torch2keras(model: torch.nn.Module,
+                input_variable,
+                keras_input_shapes=None,
+                name_policy=None,
+                verbose=True,
+                change_ordering=False,
+                raise_error_on_lambda_layers=False):
     if isinstance(input_variable, (tuple, list)):
         input_variable = tuple(torch.FloatTensor(var) for var in input_variable)
         input_names = [f'test_in{i}' for i, _ in enumerate(input_variable)]
@@ -19,7 +25,7 @@ def torch2keras(model: torch.nn.Module, input_variable, keras_input_shapes=None,
                       output_names=['test_out'])
     temp_f.seek(0)
     onnx_model = onnx.load(temp_f)
-    k_model = onnx_to_keras(onnx_model, input_names, input_shapes=keras_input_shapes, name_policy=name_policy, verbose=verbose, change_ordering=change_ordering)
+    k_model = onnx_to_keras(onnx_model, input_names, input_shapes=keras_input_shapes, name_policy=name_policy, verbose=verbose, change_ordering=change_ordering, raise_error_on_lambda_layers=raise_error_on_lambda_layers)
     return k_model
 
 
@@ -28,9 +34,10 @@ def convert(model: torch.nn.Module,
             keras_input_shapes=None,
             name_policy=None,
             verbose=True,
-            change_ordering=False):
+            change_ordering=False,
+            raise_error_on_lambda_layers=False):
     #@todo: add type hints and docstring
-    return torch2keras(model, input_variable, keras_input_shapes=keras_input_shapes, name_policy=name_policy, verbose=verbose, change_ordering=change_ordering)
+    return torch2keras(model, input_variable, keras_input_shapes=keras_input_shapes, name_policy=name_policy, verbose=verbose, change_ordering=change_ordering, raise_error_on_lambda_layers=raise_error_on_lambda_layers)
 
 
 def convert_and_test(model: torch.nn.Module,
@@ -39,8 +46,9 @@ def convert_and_test(model: torch.nn.Module,
                      name_policy=None,
                      verbose=True,
                      change_ordering=False,
+                     raise_error_on_lambda_layers=False,
                      epsilon=1e-5):
-    k_model = torch2keras(model, input_variable, keras_input_shapes=keras_input_shapes, name_policy=name_policy, verbose=verbose, change_ordering=change_ordering)
+    k_model = torch2keras(model, input_variable, keras_input_shapes=keras_input_shapes, name_policy=name_policy, verbose=verbose, change_ordering=change_ordering, raise_error_on_lambda_layers=raise_error_on_lambda_layers)
 
     error = check_torch_keras_error(model, k_model, input_variable, change_ordering=change_ordering, epsilon=epsilon)
     return error


### PR DESCRIPTION
Add argument `raise_error_on_lambda_layers` to function `onnx_to_keras`: if True, raise an error if the obtained Keras model is composed of at least one `tf.keras.layers.Lambda` layer.

This can be used as a sanity check if you intend to load the converted Keras model in a different environment; indeed, deserializing a model with `Lambda` layers in a different environment where it was saved will results in an error when calling it. This is a limitation of `Lambda` layers, (according to [Keras docs on Lambda layer](https://keras.io/api/layers/core_layers/lambda/)).